### PR TITLE
fix: image should use digest

### DIFF
--- a/k8s/nginx-deployment.yml
+++ b/k8s/nginx-deployment.yml
@@ -17,7 +17,7 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: nbpath/secure-nginx-k8s
+      - image: nbpath/secure-nginx-k8s@sha256:ba01d4407193f12a6ced769d1b0a8797e1aaedb7e2f8545c54928340da99c39a
         imagePullPolicy: Always
         name: nginx
         


### PR DESCRIPTION
This PR addresses the task in the image digest [issue](https://github.com/nbpath/secure-nginx-k8s/issues/4).
The image specification should use a digest to verify the integrity of the image used in the container.