### PR TITLE
fix: add default seccomp profile

### DIFF
--- a/k8s/nginx-deployment.yml
+++ b/k8s/nginx-deployment.yml
@@ -16,6 +16,9 @@ spec:
       labels:
         app: nginx
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - image: nbpath/secure-nginx-k8s@sha256:ba01d4407193f12a6ced769d1b0a8797e1aaedb7e2f8545c54928340da99c39a
         imagePullPolicy: Always


### PR DESCRIPTION
This PR addresses the finding described in the seccomp [issue](https://github.com/nbpath/secure-nginx-k8s/issues/8).

- Adds **securityContext** to the pod
- Sets the **seccomp** profile to the **RuntimeDefault**