### PR TITLE
fix: add container availability probes

### DIFF
--- a/k8s/nginx-deployment.yml
+++ b/k8s/nginx-deployment.yml
@@ -27,4 +27,21 @@ spec:
           capabilities:
             drop:
               - ALL
+        startupProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          periodSeconds: 3
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          failureThreshold: 5
+          periodSeconds: 3
         


### PR DESCRIPTION
This PR addresses the findings explained in the liveness and readiness probes [issue](https://github.com/nbpath/secure-nginx-k8s/issues/10).

- Add **startupProbe** to condition the start of **liveness** and **readiness** probes
- All probes are currently using http get probes
- These probes are not production ready. They are just examples on how to address the findings.