### PR TITLE
fix: add CPU and memory quotas

### DIFF
--- a/k8s/nginx-deployment.yml
+++ b/k8s/nginx-deployment.yml
@@ -23,6 +23,13 @@ spec:
       - image: nbpath/secure-nginx-k8s@sha256:ba01d4407193f12a6ced769d1b0a8797e1aaedb7e2f8545c54928340da99c39a
         imagePullPolicy: Always
         name: nginx
+        resources:
+          limits:
+            cpu: "1.0"
+            memory: "200Mi"
+          requests:
+            cpu: "0.7"
+            memory: "200Mi"
         securityContext:
           capabilities:
             drop:


### PR DESCRIPTION
Addresses the findings descried in CPU and memory [issue](https://github.com/nbpath/secure-nginx-k8s/issues/12).

- Adds the resources settings to the containers
- Limits are set for CPU and memory
- Requests are set for CPU and memory
- These are not production ready values. They are just examples.