### PR TITLE
fix: set allow privilege escalation

### DIFF
--- a/k8s/nginx-deployment.yml
+++ b/k8s/nginx-deployment.yml
@@ -31,6 +31,7 @@ spec:
             cpu: "0.7"
             memory: "200Mi"
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             drop:
               - ALL


### PR DESCRIPTION
Fix the [issue](https://github.com/nbpath/secure-nginx-k8s/issues/14) of **allowPrivilegeEscalation** set to **true** by default.

- Set container's **allowPrivilegeEscalation** to **false**