### PR TITLE
fix: run as non-root

### DIFF
--- a/k8s/nginx-deployment.yml
+++ b/k8s/nginx-deployment.yml
@@ -32,6 +32,9 @@ spec:
             memory: "200Mi"
         securityContext:
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 10001
+          runAsGroup: 10001
           capabilities:
             drop:
               - ALL


### PR DESCRIPTION
Set the container to run with the nginx user and to not execute with the root user to address the [check finding](https://github.com/nbpath/secure-nginx-k8s/issues/16).

- Set **runAsNonRoot** to **true** in the **securityContext** of the container
- Set **runAsUser** and **runAsGroup** to the nginx user and group
- This configuration depends on **usermod** and **groupmod** changes in the **Dockerfile** 