### PR TITLE
fix: disable auto-mount service account token

### DIFF
--- a/k8s/nginx-deployment.yml
+++ b/k8s/nginx-deployment.yml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: nginx
     spec:
+      automountServiceAccountToken: false
       securityContext:
         seccompProfile:
           type: RuntimeDefault


### PR DESCRIPTION
Disable the auto-mount for service account [token](https://github.com/nbpath/secure-nginx-k8s/issues/20).

- Set **automountServiceAccountToken** to **false**