### PR TITLE
fix: do not use default namespace

### DIFF
--- a/k8s/nginx-deployment.yml
+++ b/k8s/nginx-deployment.yml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: nginx
   name: nginx
-  namespace: default
+  namespace: nginx
 spec:
   replicas: 3
   revisionHistoryLimit: 10
@@ -74,4 +74,3 @@ spec:
             name: var-run
           - mountPath: /var/log/nginx/
             name: var-log
-        

--- a/k8s/nginx-namespace.yml
+++ b/k8s/nginx-namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx


### PR DESCRIPTION
Create [dedicated namespace](https://github.com/nbpath/secure-nginx-k8s/issues/22) to host the nginx deployment.

- Creates a new namespace denominated **nginx**
- Updates the nginx deployment to not use the default namespace and use the **nginx** deployment instead